### PR TITLE
Add CircleCI test config

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,24 @@
+# CircleCI service overview
+
+This service runs a number of discrete testing steps, defined as jobs in `.circleci/config.yml`.
+
+See https://circleci.com/docs/2.0 for configuration file/language specifications.
+
+Environment variable usage is encouraged to safeguard sensitive values, but usage can be fiddly as interpolation in parts of the config file will work in some parts but not others.
+
+## Running locally
+
+It is possible to debug/run the pipeline locally using the CircleCI Local CLI tool.
+
+See https://circleci.com/docs/2.0/local-cli/ for installation and further details.
+
+> TL;DR:
+
+- Install with: `brew install circleci`
+- Run individual jobs like this: `circleci local execute --job YOUR_JOB_NAME -e GITHUB_TOKEN=YOUR-TOKEN-VALUE -e ANOTHER_VAR=another_value`
+  - Note how environmental variables from CircleCI are not accessible outside of that platform. You need to pass them in as per above when running locally. That might be tricky if you don't have a certain key value; CircleCI's environment variable browser will not show you the raw value once the variable has been created.
+- Features such as parallelism, workspace sharing and directory caching won't work. You may need to adjust your job's execution steps to compensate for this.
+
+## Interaction with other supporting repos/services
+
+This is a supporting project for the NIDirect site. It provides basic, but helpful, checks to trap simple issues earlier on. The full site test pipeline at https://github.com/dof-dss/nidirect-drupal will run whenever a new version of this project is added to the `composer.lock` file of the main repo.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,66 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+version: 2
+
+jobs:
+  # Test that coding standards fit drupal.org definitions.
+  coding_standards:
+    docker:
+      - image: circleci/php:7.2.20-apache-browsers
+    steps:
+      - checkout
+      - run:
+          name: Fetch phpcs and dependencies
+          command: |
+            composer require drupal/coder --no-interaction --optimize-autoloader
+            # Move vendor directory up a level as we don't want to code-check all of that.
+            mv vendor ../
+      - run:
+          name: Fetch phpcs convenience script
+          command: |
+            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/master/phpcs.sh -o /home/circleci/project/phpcs.sh
+            chmod +x /home/circleci/project/phpcs.sh
+      - run:
+          name: PHPCS static analysis
+          command: /home/circleci/project/phpcs.sh /home/circleci "/home/circleci/project"
+
+  deprecated_code:
+    docker:
+      - image: circleci/php:7.2.20-apache-browsers
+    steps:
+      - run:
+            name: Add OS and PHP extensions
+            command: |
+              sudo apt-get update
+              sudo apt-get install -y libpng-dev
+              sudo docker-php-ext-install gd
+              composer global require hirak/prestissimo
+      # RESTORE CACHE?
+      - checkout:
+          path: /home/circleci/nidirect-d8-mig-mods
+      - run:
+          name: Fetch latest Drupal version
+          command: |
+            composer create-project drupal-composer/drupal-project:8.x-dev ${CIRCLE_WORKING_DIRECTORY} --no-interaction
+            mkdir -p ${CIRCLE_WORKING_DIRECTORY}/web/modules/migrate/nidirect-migrations
+      # SAVE CACHE?
+      - run:
+          name: Move custom code into position
+          command: mv /home/circleci/nidirect-d8-mig-mods ${CIRCLE_WORKING_DIRECTORY}/web/modules/migrate/nidirect-migrations
+      - run:
+          name: Fetch drupal-check and any dependencies
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            composer require --dev mglaman/drupal-check --no-interaction --optimize-autoloader
+      - run:
+         name: Deprecated code check
+         command: |
+            ${CIRCLE_WORKING_DIRECTORY}/vendor/bin/drupal-check ${CIRCLE_WORKING_DIRECTORY}/web/modules/migrate/nidirect-migrations
+
+workflows:
+  version: 2
+  static-analysis:
+    jobs:
+      - coding_standards
+      - deprecated_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
               sudo apt-get install -y libpng-dev
               sudo docker-php-ext-install gd
               composer global require hirak/prestissimo
-      # RESTORE CACHE?
+      # RESTORE CACHE??
       - checkout:
           path: /home/circleci/nidirect-d8-mig-mods
       - run:
@@ -44,7 +44,7 @@ jobs:
           command: |
             composer create-project drupal-composer/drupal-project:8.x-dev ${CIRCLE_WORKING_DIRECTORY} --no-interaction
             mkdir -p ${CIRCLE_WORKING_DIRECTORY}/web/modules/migrate/nidirect-migrations
-      # SAVE CACHE?
+      # SAVE CACHE??
       - run:
           name: Move custom code into position
           command: mv /home/circleci/nidirect-d8-mig-mods ${CIRCLE_WORKING_DIRECTORY}/web/modules/migrate/nidirect-migrations


### PR DESCRIPTION
PR to add:

- Static analysis of PHP code against Drupal coding standards
- Deprecated code check

The expectation is that this will automate basic code checks that should, but are often easily missed, be run locally prior to pushing code. A full stack test suite would be run on the main nidirect-drupal repo when someone updates the composer.lock file there to reference a more recent version of this repo, effectively offering an extra layer of validation and checking as part of the workflow.