### PR TITLE
D8 nid 278

### DIFF
--- a/migrate_nidirect_utils/console.services.yml
+++ b/migrate_nidirect_utils/console.services.yml
@@ -19,6 +19,11 @@ services:
     arguments: []
     tags:
       - { name: drupal.command }
+  migrate_nidirect_utils.nidirect_migrate_post_audit:
+    class: Drupal\migrate_nidirect_utils\Command\NidirectMigratePostAuditCommand
+    arguments: []
+    tags:
+      - { name: drupal.command }
   migrate_nidirect_utils.nidirect_migrate_post:
     class: Drupal\migrate_nidirect_utils\Command\NiDirectMigratePostCommand
     arguments: []

--- a/migrate_nidirect_utils/src/Command/NiDirectMigratePostCommand.php
+++ b/migrate_nidirect_utils/src/Command/NiDirectMigratePostCommand.php
@@ -29,6 +29,7 @@ class NiDirectMigratePostCommand extends ContainerAwareCommand {
     'nidirect:migrate:post:taxonomy',
     'nidirect:migrate:post:article',
     'nidirect:migrate:post:publish_status',
+    'nidirect:migrate:post:audit',
   ];
 
   /**

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostAuditCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostAuditCommand.php
@@ -6,7 +6,6 @@ use Drupal\node\Entity\Node;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\ContainerAwareCommand;
-use Drupal\Console\Annotations\DrupalCommand;
 use Drupal\Core\Database\Database;
 
 /**

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostAuditCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostAuditCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\migrate_nidirect_utils\Command;
+
+use Drupal\node\Entity\Node;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
+use Drupal\Console\Annotations\DrupalCommand;
+use Drupal\Core\Database\Database;
+
+/**
+ * Class NidirectMigratePostAuditCommand.
+ *
+ * @DrupalCommand (
+ *     extension="migrate_nidirect_utils",
+ *     extensionType="module"
+ * )
+ */
+class NidirectMigratePostAuditCommand extends ContainerAwareCommand {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this->setName('nidirect:migrate:post:audit')
+      ->setDescription($this->trans('commands.nidirect.migrate.post.audit.description'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+
+    $conn_migrate = Database::getConnection('default', 'migrate');
+    $conn_drupal8 = Database::getConnection('default', 'default');
+
+    $this->getIo()->info('Started post migration audit processing.');
+
+    // Verify Drupal 7 flag table exists.
+    if (!$conn_migrate->schema()->tableExists('flagging')) {
+      return 3;
+    }
+
+    // Select content flagged with 'content_audit' from D7.
+    $query = $conn_migrate->query("
+      SELECT 
+        f.entity_id 
+      FROM flagging f
+      JOIN node n
+      ON f.entity_id = n.nid
+      WHERE n.type in ('article', 'contact', 'page')
+      AND f.fid = 1
+    ");
+    $flag_results = $query->fetchAll();
+
+    // Update the 'next audit due' node in D8.
+    foreach ($flag_results as $i => $row) {
+      $row = (array) $row;
+      $node = Node::load($row['entity_id']);
+      // Just set next audit date to today as will show in 'needs audit' report
+      // if next audit date is today or earlier.
+      $node->set('field_next_audit_due', date('Y-m-d', \Drupal::time()->getCurrentTime()));
+      $node->save();
+      $x++;
+    }
+
+    $this->getIo()->info('Updated next audit date on ' . count($flag_results) . ' nodes.');
+  }
+
+}

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostAuditCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostAuditCommand.php
@@ -6,6 +6,7 @@ use Drupal\node\Entity\Node;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\ContainerAwareCommand;
+use Drupal\Console\Annotations\DrupalCommand;
 use Drupal\Core\Database\Database;
 
 /**
@@ -54,14 +55,14 @@ class NidirectMigratePostAuditCommand extends ContainerAwareCommand {
     $flag_results = $query->fetchAll();
 
     // Update the 'next audit due' node in D8.
+    $today = date('Y-m-d', \Drupal::time()->getCurrentTime());
     foreach ($flag_results as $i => $row) {
       $row = (array) $row;
       $node = Node::load($row['entity_id']);
       // Just set next audit date to today as will show in 'needs audit' report
       // if next audit date is today or earlier.
-      $node->set('field_next_audit_due', date('Y-m-d', \Drupal::time()->getCurrentTime()));
+      $node->set('field_next_audit_due', $today);
       $node->save();
-      $x++;
     }
 
     $this->getIo()->info('Updated next audit date on ' . count($flag_results) . ' nodes.');

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostFlagCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostFlagCommand.php
@@ -57,6 +57,8 @@ class NidirectMigratePostFlagCommand extends ContainerAwareCommand {
     $query = $conn_drupal8->delete('flagging')->execute();
 
     // Flag counts.
+    // (Exclude 'content_audit' flag as auditing has been implemented
+    // without a flag in Drupal 8)
     $query = $conn_migrate->query("
       SELECT
         CASE fid
@@ -72,11 +74,13 @@ class NidirectMigratePostFlagCommand extends ContainerAwareCommand {
         count,
         last_updated
       FROM {flag_counts}
-      WHERE fid <> 3
+      WHERE fid in (2,4,5,6,7)
     ");
     $flag_count_results = $query->fetchAll();
 
     // Flagging.
+    // (Exclude 'content_audit' flag as auditing has been implemented
+    // without a flag in Drupal 8)
     $query = $conn_migrate->query("
       SELECT
         flagging_id as id,
@@ -94,7 +98,7 @@ class NidirectMigratePostFlagCommand extends ContainerAwareCommand {
         sid as session_id,
         timestamp as created
       FROM {flagging}
-      WHERE fid <> 3
+      WHERE fid in (2,4,5,6,7)
     ");
     $flagging_results = $query->fetchAll();
 


### PR DESCRIPTION
- Exclude 'content audit' flags from the post migration flag command as they are now handled in a different way (by 'next audit due' date field).

- Create a new post migration audit command to update the 'next audit due' date on all nodes that were flagged for audit in D7.