### PR TITLE
D8NID-386 ~ Remove path aliases task

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ are enabled.
 * migrate_nidirect_node_page
 * migrate_nidirect_node_publication
 * migrate_nidirect_node_recipe
-* migrate_nidirect_links
+* migrate_nidirect_link
+* upgrade_d7_url_alias
+* upgrade_d7_path_redirect
 
 ## Running tests
 

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePreCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePreCommand.php
@@ -139,27 +139,4 @@ class NidirectMigratePreCommand extends MigrateCommand {
     $this->drupal7DatabaseQuery("UPDATE redirect SET status_code=301 WHERE status_code=0 OR status_code IS NULL");
   }
 
-  /**
-   * Import Drupal 7 URL aliases.
-   */
-  // phpcs:disable
-  protected function task_import_url_aliases() {
-  // phpcs:enable
-    $aliases_query = $this->connMigrate->query('SELECT pid, source, alias FROM url_alias');
-    $aliases = $aliases_query->fetchAllAssoc('pid');
-
-    $insert = $this->connDefault->insert('url_alias')->fields([
-      'pid',
-      'source',
-      'alias',
-      'langcode',
-    ]);
-
-    foreach ($aliases as $pid => $alias) {
-      $insert->values([$pid, '/' . $alias->source, '/' . $alias->alias, 'und']);
-    }
-
-    $insert->execute();
-  }
-
 }


### PR DESCRIPTION
URL aliases are now entities in their own right. 
Use the 'upgrade_d7_urk_alias' instead.
url_alias table is retained for backup purposes.