### PR TITLE
D8NID-382 media reference fields to replace image fields

### DIFF
--- a/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_document.yml
+++ b/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_document.yml
@@ -30,7 +30,7 @@ process:
       source: uid
     -
       plugin: migration
-      migration: my_users
+      migration: upgrade_d7_user
   status: status
   created: timestamp
   changed: timestamp

--- a/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_image.yml
+++ b/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_image.yml
@@ -25,9 +25,9 @@ process:
   name: filename
   uid:
     -
-      plugin: skip_on_empty
-      method: process
+      plugin: default_value
       source: uid
+      default_value: 1
     -
       plugin: migration
       migration: my_users

--- a/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_image.yml
+++ b/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_image.yml
@@ -24,13 +24,12 @@ process:
     default_value: "und"
   name: filename
   uid:
-    -
-      plugin: default_value
+    - plugin: skip_on_empty
+      method: process
       source: uid
-      default_value: 1
     -
       plugin: migration
-      migration: my_users
+      migration: upgrade_d7_user
   status: status
   created: timestamp
   changed: timestamp

--- a/migrate_nidirect_file/src/Plugin/migrate/process/MediaWysiwygFilter.php
+++ b/migrate_nidirect_file/src/Plugin/migrate/process/MediaWysiwygFilter.php
@@ -61,6 +61,8 @@ TEMPLATE;
       $decoder = new JsonDecode(TRUE);
       try {
         $tag_info = $decoder->decode($matches['tag_info'], JsonEncoder::FORMAT);
+        // Convert any 'default' view modes to 'embed'.
+        $tag_info['view_mode'] = str_replace('default', 'embed', $tag_info['view_mode']);
         return sprintf($replacement_template, $tag_info['view_mode'], $tag_info['fid']);
       }
       catch (NotEncodableValueException $e) {

--- a/migrate_nidirect_node/migrate_nidirect_node_article/config/install/migrate_plus.migration.node_article.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_article/config/install/migrate_plus.migration.node_article.yml
@@ -96,21 +96,21 @@ process:
       plugin: sub_process
       source: field_photo
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_banner_image:
     -
       plugin: sub_process
       source: field_banner_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_additional_info:
     -
       plugin: get
@@ -138,3 +138,4 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_comment_field_instance
     - upgrade_d7_taxonomy_term_site_themes
+    - upgrade_d7_file_image

--- a/migrate_nidirect_node/migrate_nidirect_node_article/config/install/migrate_plus.migration.node_revision_article.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_article/config/install/migrate_plus.migration.node_revision_article.yml
@@ -99,21 +99,21 @@ process:
       plugin: sub_process
       source: field_photo
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_banner_image:
     -
       plugin: sub_process
       source: field_banner_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_additional_info:
     -
       plugin: get

--- a/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeRevisionSource.php
+++ b/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeRevisionSource.php
@@ -10,6 +10,7 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "driving_instructor_node_revision_source",
+ *   source_module = "migrate_nidirect_node_driving_instructor"
  * )
  */
 class NIDirectDrivingInstructorNodeRevisionSource extends NodeRevision {

--- a/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeSource.php
+++ b/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeSource.php
@@ -10,6 +10,7 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "driving_instructor_node_source",
+ *   source_module = "migrate_nidirect_node_driving_instructor"
  * )
  */
 class NIDirectDrivingInstructorNodeSource extends Node {

--- a/migrate_nidirect_node/migrate_nidirect_node_health_condition/config/install/migrate_plus.migration.node_health_condition.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_health_condition/config/install/migrate_plus.migration.node_health_condition.yml
@@ -72,27 +72,25 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_banner_image:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_banner_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_enable_toc: field_enable_toc
   field_index_letter: field_index_letter
   field_photo:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_photo
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_site_topics:
     -
       plugin: sub_process
@@ -229,3 +227,4 @@ migration_dependencies:
   required:
     - upgrade_d7_user
     - upgrade_d7_taxonomy_term_site_themes
+    - upgrade_d7_file_image

--- a/migrate_nidirect_node/migrate_nidirect_node_health_condition/config/install/migrate_plus.migration.node_revision_health_condition.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_health_condition/config/install/migrate_plus.migration.node_revision_health_condition.yml
@@ -72,27 +72,25 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_banner_image:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_banner_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_enable_toc: field_enable_toc
   field_index_letter: field_index_letter
   field_photo:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_photo
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_site_topics:
     -
       plugin: sub_process

--- a/migrate_nidirect_node/migrate_nidirect_node_landing_page/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_landing_page/config/install/migrate_plus.migration.node_landing_page.yml
@@ -52,15 +52,14 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_banner_image:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_banner_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_subtheme:
     -
       plugin: sub_process
@@ -95,15 +94,14 @@ process:
         target_id: tid
   field_enable_title: field_enable_title
   field_banner_image_overlay:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_banner_image_overlay
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
 destination:
   plugin: 'entity:node'
   default_bundle: landing_page
@@ -111,3 +109,4 @@ migration_dependencies:
   required:
     - upgrade_d7_user
     - upgrade_d7_taxonomy_term_site_themes
+    - upgrade_d7_file_image

--- a/migrate_nidirect_node/migrate_nidirect_node_landing_page/config/install/migrate_plus.migration.node_revision_landing_page.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_landing_page/config/install/migrate_plus.migration.node_revision_landing_page.yml
@@ -52,15 +52,14 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_banner_image:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_banner_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_subtheme:
     -
       plugin: sub_process
@@ -95,15 +94,14 @@ process:
         target_id: tid
   field_enable_title: field_enable_title
   field_banner_image_overlay:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_banner_image_overlay
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
 destination:
   plugin: 'entity_revision:node'
   default_bundle: landing_page

--- a/migrate_nidirect_node/migrate_nidirect_node_news/config/install/migrate_plus.migration.node_news.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_news/config/install/migrate_plus.migration.node_news.yml
@@ -47,15 +47,14 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_photo:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_photo
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_published_date:
     -
       plugin: sub_process
@@ -93,6 +92,6 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_user
-    - upgrade_d7_file
+    - upgrade_d7_file_image
   optional:
     - upgrade_d7_comment_field_instance

--- a/migrate_nidirect_node/migrate_nidirect_node_news/config/install/migrate_plus.migration.node_revision_news.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_news/config/install/migrate_plus.migration.node_revision_news.yml
@@ -49,15 +49,14 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_photo:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_photo
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_published_date:
     -
       plugin: sub_process

--- a/migrate_nidirect_node/migrate_nidirect_node_recipe/config/install/migrate_plus.migration.node_recipe.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_recipe/config/install/migrate_plus.migration.node_recipe.yml
@@ -55,11 +55,11 @@ process:
       plugin: sub_process
       source: field_recipe_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_recipe_other_options:
     -
       plugin: get
@@ -202,7 +202,7 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_user
-    - upgrade_d7_file
+    - upgrade_d7_file_image
     - upgrade_d7_recipe_course_type
     - upgrade_d7_recipe_ingredient
     - upgrade_d7_recipe_special_diet

--- a/migrate_nidirect_node/migrate_nidirect_node_recipe/config/install/migrate_plus.migration.node_revision_recipe.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_recipe/config/install/migrate_plus.migration.node_revision_recipe.yml
@@ -53,15 +53,14 @@ process:
   field_recipe_serves: field_recipe_serves
   field_recipe_allergens: field_recipe_allergens
   field_recipe_image:
-    -
-      plugin: sub_process
+    - plugin: sub_process
       source: field_recipe_image
       process:
-        target_id: fid
-        alt: alt
-        title: title
-        width: width
-        height: height
+        target_id:
+          plugin: migration_lookup
+          migration:
+            - upgrade_d7_file_image
+          source: fid
   field_recipe_other_options:
     -
       plugin: get

--- a/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldNodeSource.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldNodeSource.php
@@ -11,6 +11,7 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "phone_field_node_source",
+ *   source_module = "migrate_nidirect_node"
  * )
  */
 class NIDirectPhoneFieldNodeSource extends Node {

--- a/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldRevisionNodeSource.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldRevisionNodeSource.php
@@ -11,6 +11,7 @@ use Drupal\node\Plugin\migrate\source\d7\NodeRevision;
  *
  * @MigrateSource(
  *   id = "phone_field_revision_node_source",
+ *   source_module = "migrate_nidirect_node"
  * )
  */
 class NIDirectPhoneFieldRevisionNodeSource extends NodeRevision {


### PR DESCRIPTION
As the fields have changed type the migration config needs to adapt too. Rather than using the source file id/attributes, we now need to use a migration lookup process plugin to gather the correct values for these fields.