### PR TITLE
Migration source bugfix

### DIFF
--- a/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeRevisionSource.php
+++ b/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeRevisionSource.php
@@ -10,7 +10,6 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "driving_instructor_node_revision_source",
- *   source_module = "migrate_nidirect_node_driving_instructor"
  * )
  */
 class NIDirectDrivingInstructorNodeRevisionSource extends NodeRevision {

--- a/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeSource.php
+++ b/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeSource.php
@@ -10,7 +10,6 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "driving_instructor_node_source",
- *   source_module = "migrate_nidirect_node_driving_instructor"
  * )
  */
 class NIDirectDrivingInstructorNodeSource extends Node {

--- a/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldNodeSource.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldNodeSource.php
@@ -11,7 +11,6 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "phone_field_node_source",
- *   source_module = "migrate_nidirect_node"
  * )
  */
 class NIDirectPhoneFieldNodeSource extends Node {

--- a/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldRevisionNodeSource.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldRevisionNodeSource.php
@@ -11,7 +11,6 @@ use Drupal\node\Plugin\migrate\source\d7\NodeRevision;
  *
  * @MigrateSource(
  *   id = "phone_field_revision_node_source",
- *   source_module = "migrate_nidirect_node"
  * )
  */
 class NIDirectPhoneFieldRevisionNodeSource extends NodeRevision {


### PR DESCRIPTION
source_module was set incorrectly in these migration plugins, which was causing them to fail.

The modules listed are D8 modules so they will not be enabled in the 'source' database (they are 'destination' modules).