### PR TITLE
Set correct source_module (data source module) to correctly register plugins

### DIFF
--- a/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeRevisionSource.php
+++ b/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeRevisionSource.php
@@ -10,6 +10,7 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "driving_instructor_node_revision_source",
+ *   source_module = "node"
  * )
  */
 class NIDirectDrivingInstructorNodeRevisionSource extends NodeRevision {

--- a/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeSource.php
+++ b/migrate_nidirect_node/migrate_nidirect_node_driving_instructor/src/Plugin/migrate/source/NIDirectDrivingInstructorNodeSource.php
@@ -10,6 +10,7 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "driving_instructor_node_source",
+ *   source_module = "node"
  * )
  */
 class NIDirectDrivingInstructorNodeSource extends Node {

--- a/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldNodeSource.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldNodeSource.php
@@ -11,6 +11,7 @@ use Drupal\migrate\Row;
  *
  * @MigrateSource(
  *   id = "phone_field_node_source",
+ *   source_module = "node"
  * )
  */
 class NIDirectPhoneFieldNodeSource extends Node {

--- a/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldRevisionNodeSource.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/source/NIDirectPhoneFieldRevisionNodeSource.php
@@ -11,6 +11,7 @@ use Drupal\node\Plugin\migrate\source\d7\NodeRevision;
  *
  * @MigrateSource(
  *   id = "phone_field_revision_node_source",
+ *   source_module = "node"
  * )
  */
 class NIDirectPhoneFieldRevisionNodeSource extends NodeRevision {


### PR DESCRIPTION
The annotation semantics are ambiguous. It _looks_ as if it needs you to indicate what module provides this plugin, but it actually is asking you to indicate what module provides the data from the source system/database. In this case, it's 'node'.