### PR TITLE
D8 nid 486

### DIFF
--- a/migrate_nidirect_node/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/migrate_nidirect_node/src/EventSubscriber/PostMigrationSubscriber.php
@@ -79,6 +79,9 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     if (substr($event_id, 0, 5) == 'node_') {
       $content_type = substr($event_id, 5);
       $this->logger->notice($this->migrationProcessors->PublishingStatus($content_type));
+      if (preg_match('/revision_/', $content_type)) {
+        $this->logger->notice($this->migrationProcessors->RevisionStatus($content_type));
+      }
       $this->logger->notice($this->migrationProcessors->flags($content_type));
       $this->logger->notice($this->migrationProcessors->metatags());
 

--- a/migrate_nidirect_node/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/migrate_nidirect_node/src/EventSubscriber/PostMigrationSubscriber.php
@@ -78,9 +78,9 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     // Only process nodes, nothing else.
     if (substr($event_id, 0, 5) == 'node_') {
       $content_type = substr($event_id, 5);
-      $this->logger->notice($this->migrationProcessors->PublishingStatus($content_type));
+      $this->logger->notice($this->migrationProcessors->publishingStatus($content_type));
       if (preg_match('/revision_/', $content_type)) {
-        $this->logger->notice($this->migrationProcessors->RevisionStatus($content_type));
+        $this->logger->notice($this->migrationProcessors->revisionStatus($content_type));
       }
       $this->logger->notice($this->migrationProcessors->flags($content_type));
       $this->logger->notice($this->migrationProcessors->metatags());

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -132,13 +132,13 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
       ->condition('nid', $nid)
       ->execute();
 
+    // Make sure that we have a 'published' revision.
     $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
       ->fields(['moderation_state' => 'published'])
       ->condition('content_entity_id', $nid)
       ->condition('content_entity_revision_id', $vid)
       ->execute();
 
-    // Make sure that we have a 'published' revision.
     $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
       ->fields(['moderation_state' => 'published'])
       ->condition('content_entity_id', $nid)

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Core\Database\Database;
+use Drupal\Console\Annotations\DrupalCommand;
 
 /**
  * Class NidirectMigratePostPublishStatusCommand.

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -37,9 +37,10 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
   /**
    * {@inheritdoc}
    */
-  public function __construct(ModuleHandler $module_handler, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct() {
     $this->dbConnMigrate = Database::getConnection('default', 'migrate');
     $this->dbConnDrupal8 = Database::getConnection('default', 'default');
+    parent::__construct();
   }
 
   /**

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -2,12 +2,11 @@
 
 namespace Drupal\migrate_nidirect_utils\Command;
 
-use Drupal\Core\Database\Connection;
-use Drupal\node\Entity\Node;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandler;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\ContainerAwareCommand;
-use Drupal\Console\Annotations\DrupalCommand;
 use Drupal\Core\Database\Database;
 
 /**
@@ -19,6 +18,28 @@ use Drupal\Core\Database\Database;
  * )
  */
 class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
+
+  /**
+   * Migration database connection (Drupal 7).
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $dbConnMigrate;
+
+  /**
+   * Drupal 8 database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $dbConnDrupal8;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ModuleHandler $module_handler, EntityTypeManagerInterface $entity_type_manager) {
+    $this->dbConnMigrate = Database::getConnection('default', 'migrate');
+    $this->dbConnDrupal8 = Database::getConnection('default', 'default');
+  }
 
   /**
    * {@inheritdoc}
@@ -33,17 +54,15 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
 
-    $conn_migrate = Database::getConnection('default', 'migrate');
-    $conn_drupal8 = Database::getConnection('default', 'default');
     $this->getIo()->info('Sync node publish status values after migration');
 
     // Find all out current node ids in the D8 site so we know what to look for.
     $d8_nids = [];
-    $query = $conn_drupal8->query("SELECT nid FROM {node} ORDER BY nid ASC");
+    $query = $this->dbConnDrupal8->query("SELECT nid FROM {node} ORDER BY nid ASC");
     $d8_nids = $query->fetchAllAssoc('nid');
 
     // Load source node publish status fields.
-    $query = $conn_migrate->query("
+    $query = $this->dbConnMigrate->query("
       SELECT nid, status FROM {node}
       WHERE nid IN (:nids[])
       ORDER BY nid ASC
@@ -52,7 +71,7 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
 
     // Sync our D8 node publish values and revisions with those from D7.
     foreach ($migrate_nid_status as $row) {
-      $this->processNodeStatus($conn_migrate, $conn_drupal8, $row->nid, $row->status);
+      $this->processNodeStatus($row->nid, $row->status);
     }
 
     $this->getIo()->info('Updated revisions on ' . count($migrate_nid_status) . ' nodes.');
@@ -63,64 +82,62 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
   /**
    * Updates the status and revisions for the specified node.
    *
-   * @param Drupal\Core\Database\Connection $conn_migrate
-   *   Drupal 7 database connection.
-   * @param Drupal\Core\Database\Connection $conn_drupal8
-   *   Drupal 8 database connection.
    * @param int $nid
    *   The node id.
    * @param string $status
    *   The status of the node.
-   *
    */
-  private function processNodeStatus(Connection $conn_migrate, Connection $conn_drupal8, int $nid, string $status) {
-    // Need to fetch the D8 revision ID for any node as it doesn't always match the source db.
-    $d8_vid = $conn_drupal8->query(
+  private function processNodeStatus(int $nid, string $status) {
+    // Need to fetch the D8 revision ID for any node as it doesn't
+    // always match the source db.
+    $d8_vid = $this->dbConnDrupal8->query(
       "SELECT vid FROM {node_field_data} WHERE nid = :nid", [':nid' => $nid]
     )->fetchField();
 
-    // Run an update statement per item. Refinement might be to run a cross-DB SELECT query to power an UPDATE using a JOIN.
-    $query = $conn_drupal8->update('node_field_data')
+    // Run an update statement per item. Refinement might be to run a
+    // cross-DB SELECT query to power an UPDATE using a JOIN.
+    $query = $this->dbConnDrupal8->update('node_field_data')
       ->fields(['status' => $status])
       ->condition('nid', $nid)
       ->execute();
 
-    $query = $conn_drupal8->update('node_field_revision')
+    $query = $this->dbConnDrupal8->update('node_field_revision')
       ->fields(['status' => $status])
       ->condition('nid', $nid)
       ->condition('vid', $d8_vid)
       ->execute();
 
     // Get the D7 revision id.
-    $vid = $conn_migrate->query(
+    $vid = $this->dbConnMigrate->query(
       "SELECT vid FROM {node} WHERE nid = :nid", [':nid' => $nid]
     )->fetchField();
 
     // Update the current revision if necessary.
     if ($vid != $d8_vid) {
-      $vid = $this->updateCurrentRevision($conn_migrate, $conn_drupal8, $nid, $vid, $d8_vid);
+      $vid = $this->updateCurrentRevision($nid, $vid, $d8_vid);
     }
 
     // The 'revision_translation_affected' field is poorly documented (and
     // understood) in Drupal core, and is sometimes set to NULL after migrating
     // content from Drupal 7. There is much discussion at
     // https://www.drupal.org/project/drupal/issues/2746541 but after testing
-    // and investigation I am yet to find a case where it should not be set to '1'.
-    // Hence, we set it to '1' across the board to solve the problem of revisions
-    // not appearing on the revisions tab.
-    $query = $conn_drupal8->update('node_field_revision')
+    // and investigation I am yet to find a case where it should not be
+    // set to '1'.
+    // Hence, we set it to '1' across the board to solve the problem
+    // of revisions not appearing on the revisions tab.
+    $query = $this->dbConnDrupal8->update('node_field_revision')
       ->fields(['revision_translation_affected' => 1])
       ->condition('nid', $nid)
       ->execute();
 
-    $query = $conn_drupal8->update('content_moderation_state_field_data')
+    $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
       ->fields(['moderation_state' => 'published'])
       ->condition('content_entity_id', $nid)
       ->condition('content_entity_revision_id', $vid)
       ->execute();
 
     // Make sure that we have a 'published' revision.
-    $query = $conn_drupal8->update('content_moderation_state_field_revision')
+    $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
       ->fields(['moderation_state' => 'published'])
       ->condition('content_entity_id', $nid)
       ->condition('content_entity_revision_id', $vid)
@@ -130,10 +147,6 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
   /**
    * Updates the current revision for the given node.
    *
-   * @param Drupal\Core\Database\Connection $conn_migrate
-   *   Drupal 7 database connection.
-   * @param Drupal\Core\Database\Connection $conn_drupal8
-   *   Drupal 8 database connection.
    * @param int $nid
    *   The node id.
    * @param int $vid
@@ -144,14 +157,14 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
    * @return string
    *   Current revision id.
    */
-  private function updateCurrentRevision(Connection $conn_migrate, Connection $conn_drupal8, int $nid, int $vid, int $d8_vid) {
+  private function updateCurrentRevision(int $nid, int $vid, int $d8_vid) {
     // Does this revision exist in D8 ?
-    $check_vid = $conn_drupal8->query(
+    $check_vid = $this->dbConnDrupal8->query(
       "SELECT vid FROM {node_field_revision} WHERE nid = :nid AND vid = :vid", [':nid' => $nid, ':vid' => $vid]
     )->fetchField();
     if (!empty($check_vid)) {
       // Does the current D8 revision exist in D7 ?
-      $check_d7_vid = $conn_migrate->query(
+      $check_d7_vid = $this->dbConnMigrate->query(
         "SELECT vid FROM {node_revision} WHERE nid = :nid and vid = :vid", [':nid' => $nid, ':vid' => $d8_vid]
       )->fetchField();
       if (!empty($check_d7_vid)) {
@@ -159,11 +172,11 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
         // N.B. This will only work in the 'one hit' migration scenario, it may
         // cause problems if the migration runs again and in the meantime the
         // editors have reverted to an older revision that also came from D7.
-        $query = $conn_drupal8->update('node')
+        $query = $this->dbConnDrupal8->update('node')
           ->fields(['vid' => $vid])
           ->condition('nid', $nid)
           ->execute();
-        $query = $conn_drupal8->update('node_field_data')
+        $query = $this->dbConnDrupal8->update('node_field_data')
           ->fields(['vid' => $vid])
           ->condition('nid', $nid)
           ->execute();
@@ -174,6 +187,5 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
       return $d8_vid;
     }
   }
-
 
 }

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\migrate_nidirect_utils\Command;
 
+use Drupal\Core\Database\Connection;
 use Drupal\node\Entity\Node;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,61 +50,9 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
     ", [':nids[]' => array_keys($d8_nids)]);
     $migrate_nid_status = $query->fetchAll();
 
-    // Sync our D8 node publish values with those from D7.
-    // There are three tables that need an adjustment ranging
-    // from node revisions to content moderation tracking tables.
+    // Sync our D8 node publish values and revisions with those from D7.
     foreach ($migrate_nid_status as $row) {
-      // Need to fetch the D8 revision ID for any node as it doesn't always match the source db.
-      $d8_vid = $conn_drupal8->query(
-        "SELECT vid FROM {node_field_data} WHERE nid = :nid", [':nid' => $row->nid]
-        )->fetchField();
-
-      // Run an update statement per item. Refinement might be to run a cross-DB SELECT query to power an UPDATE using a JOIN.
-      $query = $conn_drupal8->update('node_field_data')
-        ->fields(['status' => $row->status])
-        ->condition('nid', $row->nid)
-        ->execute();
-
-      $query = $conn_drupal8->update('node_field_revision')
-        ->fields(['status' => $row->status])
-        ->condition('nid', $row->nid)
-        ->condition('vid', $d8_vid)
-        ->execute();
-
-      // Get the D7 revision id.
-      $vid = $conn_migrate->query(
-        "SELECT vid FROM {node} WHERE nid = :nid", [':nid' => $row->nid]
-      )->fetchField();
-
-      // Update the current revision if necessary.
-      if ($vid != $d8_vid) {
-        $vid = $this->updateCurrentRevision($conn_migrate, $conn_drupal8, $row->nid, $vid, $d8_vid);
-      }
-
-      // The 'revision_translation_affected' field is poorly documented (and
-      // understood) in Drupal core, and is sometimes set to NULL after migrating
-      // content from Drupal 7. There is much discussion at
-      // https://www.drupal.org/project/drupal/issues/2746541 but after testing
-      // and investigation I am yet to find a case where it should not be set to '1'.
-      // Hence, we set it to '1' across the board to solve the problem of revisions
-      // not appearing on the revisions tab.
-      $query = $conn_drupal8->update('node_field_revision')
-        ->fields(['revision_translation_affected' => 1])
-        ->condition('nid', $row->nid)
-        ->execute();
-
-      $query = $conn_drupal8->update('content_moderation_state_field_data')
-        ->fields(['moderation_state' => 'published'])
-        ->condition('content_entity_id', $row->nid)
-        ->condition('content_entity_revision_id', $vid)
-        ->execute();
-
-      // Make sure that we have a 'published' revision.
-      $query = $conn_drupal8->update('content_moderation_state_field_revision')
-        ->fields(['moderation_state' => 'published'])
-        ->condition('content_entity_id', $row->nid)
-        ->condition('content_entity_revision_id', $vid)
-        ->execute();
+      $this->processNodeStatus($conn_migrate, $conn_drupal8, $row->nid, $row->status);
     }
 
     $this->getIo()->info('Updated revisions on ' . count($migrate_nid_status) . ' nodes.');
@@ -112,8 +61,79 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
   }
 
   /**
+   * Updates the status and revisions for the specified node.
+   *
+   * @param Drupal\Core\Database\Connection $conn_migrate
+   *   Drupal 7 database connection.
+   * @param Drupal\Core\Database\Connection $conn_drupal8
+   *   Drupal 8 database connection.
+   * @param int $nid
+   *   The node id.
+   * @param string $status
+   *   The status of the node.
+   *
+   */
+  private function processNodeStatus(Connection $conn_migrate, Connection $conn_drupal8, int $nid, string $status) {
+    // Need to fetch the D8 revision ID for any node as it doesn't always match the source db.
+    $d8_vid = $conn_drupal8->query(
+      "SELECT vid FROM {node_field_data} WHERE nid = :nid", [':nid' => $nid]
+    )->fetchField();
+
+    // Run an update statement per item. Refinement might be to run a cross-DB SELECT query to power an UPDATE using a JOIN.
+    $query = $conn_drupal8->update('node_field_data')
+      ->fields(['status' => $status])
+      ->condition('nid', $nid)
+      ->execute();
+
+    $query = $conn_drupal8->update('node_field_revision')
+      ->fields(['status' => $status])
+      ->condition('nid', $nid)
+      ->condition('vid', $d8_vid)
+      ->execute();
+
+    // Get the D7 revision id.
+    $vid = $conn_migrate->query(
+      "SELECT vid FROM {node} WHERE nid = :nid", [':nid' => $nid]
+    )->fetchField();
+
+    // Update the current revision if necessary.
+    if ($vid != $d8_vid) {
+      $vid = $this->updateCurrentRevision($conn_migrate, $conn_drupal8, $nid, $vid, $d8_vid);
+    }
+
+    // The 'revision_translation_affected' field is poorly documented (and
+    // understood) in Drupal core, and is sometimes set to NULL after migrating
+    // content from Drupal 7. There is much discussion at
+    // https://www.drupal.org/project/drupal/issues/2746541 but after testing
+    // and investigation I am yet to find a case where it should not be set to '1'.
+    // Hence, we set it to '1' across the board to solve the problem of revisions
+    // not appearing on the revisions tab.
+    $query = $conn_drupal8->update('node_field_revision')
+      ->fields(['revision_translation_affected' => 1])
+      ->condition('nid', $nid)
+      ->execute();
+
+    $query = $conn_drupal8->update('content_moderation_state_field_data')
+      ->fields(['moderation_state' => 'published'])
+      ->condition('content_entity_id', $nid)
+      ->condition('content_entity_revision_id', $vid)
+      ->execute();
+
+    // Make sure that we have a 'published' revision.
+    $query = $conn_drupal8->update('content_moderation_state_field_revision')
+      ->fields(['moderation_state' => 'published'])
+      ->condition('content_entity_id', $nid)
+      ->condition('content_entity_revision_id', $vid)
+      ->execute();
+  }
+
+  /**
    * Updates the current revision for the given node.
    *
+   * @param Drupal\Core\Database\Connection $conn_migrate
+   *   Drupal 7 database connection.
+   * @param Drupal\Core\Database\Connection $conn_drupal8
+   *   Drupal 8 database connection.
    * @param int $nid
    *   The node id.
    * @param int $vid
@@ -124,7 +144,7 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
    * @return string
    *   Current revision id.
    */
-  private function updateCurrentRevision($conn_migrate, $conn_drupal8, int $nid, int $vid, int $d8_vid) {
+  private function updateCurrentRevision(Connection $conn_migrate, Connection $conn_drupal8, int $nid, int $vid, int $d8_vid) {
     // Does this revision exist in D8 ?
     $check_vid = $conn_drupal8->query(
       "SELECT vid FROM {node_field_revision} WHERE nid = :nid AND vid = :vid", [':nid' => $nid, ':vid' => $vid]

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -70,7 +70,26 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
         ->condition('vid', $vid)
         ->execute();
 
+      // The 'revision_translation_affected' field is poorly documented (and
+      // understood) in Drupal core, and is sometimes set to NULL after migrating
+      // content from Drupal 7. There is much discussion at
+      // https://www.drupal.org/project/drupal/issues/2746541 but after testing
+      // and investigation I am yet to find a case where it should not be set to '1'.
+      // Hence, we set it to '1' across the board to solve the problem of revisions
+      // not appearing on the revisions tab.
+      $query = $conn_drupal8->update('node_field_revision')
+        ->fields(['revision_translation_affected' => 1])
+        ->condition('nid', $row->nid)
+        ->execute();
+
       $query = $conn_drupal8->update('content_moderation_state_field_data')
+        ->fields(['moderation_state' => 'published'])
+        ->condition('content_entity_id', $row->nid)
+        ->condition('content_entity_revision_id', $vid)
+        ->execute();
+
+      // Make sure that we have a 'published' revision.
+      $query = $conn_drupal8->update('content_moderation_state_field_revision')
         ->fields(['moderation_state' => 'published'])
         ->condition('content_entity_id', $row->nid)
         ->condition('content_entity_revision_id', $vid)

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -506,6 +506,11 @@ class MigrationProcessors {
       }
     }
 
+    if (count($nids_to_update > 0)) {
+      // Must flush all caches or the SQL insertion above will not take effect.
+      drupal_flush_all_caches();
+    }
+
     if (count($error_nids) > 0) {
       return "Unable to process audit for nids: " . implode(',', $error_nids);
     }

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -506,7 +506,7 @@ class MigrationProcessors {
       }
     }
 
-    if (count($nids_to_update > 0)) {
+    if (count($nids_to_update) > 0) {
       // Must flush all caches or the SQL insertion above will not take effect.
       drupal_flush_all_caches();
     }

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -61,7 +61,7 @@ class MigrationProcessors {
    * @return string
    *   Information/results of on the process.
    */
-  public function RevisionStatus(string $node_type) {
+  public function revisionStatus(string $node_type) {
     // Find all out current node ids in the D8 site so we know what to look for.
     $d8_nids = [];
     $node_type = preg_replace('/revision_/', '', $node_type);
@@ -95,12 +95,13 @@ class MigrationProcessors {
       }
 
       // The 'revision_translation_affected' field is poorly documented (and
-      // understood) in Drupal core, and is sometimes set to NULL after migrating
+      // understood) in Drupal core and is sometimes set to NULL after migrating
       // content from Drupal 7. There is much discussion at
       // https://www.drupal.org/project/drupal/issues/2746541 but after testing
-      // and investigation I am yet to find a case where it should not be set to '1'.
-      // Hence, we set it to '1' across the board to solve the problem of revisions
-      // not appearing on the revisions tab.
+      // and investigation no cases have been found where it should
+      // not be set to '1'.
+      // Hence, we set it to '1' across the board to solve the problem of
+      // revisions not appearing on the revisions tab.
       $query = $this->dbConnDrupal8->update('node_field_revision')
         ->fields(['revision_translation_affected' => 1])
         ->condition('nid', $row->nid)
@@ -130,7 +131,7 @@ class MigrationProcessors {
    *   The node id.
    * @param int $vid
    *   The target revision id (from D7).
-   * @param int $nid
+   * @param int $d8_vid
    *   The current D8 revision id.
    *
    * @return string
@@ -148,9 +149,9 @@ class MigrationProcessors {
       )->fetchField();
       if (!empty($check_d7_vid)) {
         // Make the D7 revision the current revision in D8.
-        // N.B. This will only work in the 'one hit' migration scenario, it may cause problems
-        // if the migration runs again and in the meantime the editors have reverted to an older
-        // revision that also came from D7.
+        // N.B. This will only work in the 'one hit' migration scenario, it may
+        // cause problems if the migration runs again and in the meantime the
+        // editors have reverted to an older revision that also came from D7.
         $query = $this->dbConnDrupal8->update('node')
           ->fields(['vid' => $vid])
           ->condition('nid', $nid)
@@ -161,7 +162,8 @@ class MigrationProcessors {
           ->execute();
       }
       return $vid;
-    } else {
+    }
+    else {
       return $d8_vid;
     }
   }
@@ -472,7 +474,8 @@ class MigrationProcessors {
             'last_updated',
           ]);
           foreach ($flag_count_data as $row) {
-            // Check we haven't already got this present in the destination table.
+            // Check we haven't already got this present in the destination
+            // table.
             if (array_key_exists($row['entity_id'], $d8_flag_counts) == FALSE) {
               $query->values($row);
             }
@@ -570,7 +573,8 @@ class MigrationProcessors {
         if ($node->hasField('field_next_audit_due')) {
           // Just set next audit date to today as will show in 'needs audit'
           // report if next audit date is today or earlier.
-          // Avoid creating a new revision here by updating the existing revision directly.
+          // Avoid creating a new revision here by updating the existing
+          // revision directly.
           $vid = $this->dbConnDrupal8->query(
             "SELECT vid FROM {node_field_data} WHERE nid = :nid", [':nid' => $nid]
           )->fetchField();
@@ -579,13 +583,15 @@ class MigrationProcessors {
           )->fetchField();
           if (!empty($vid) && !empty($langcode)) {
             $query = $this->dbConnDrupal8->insert('node__field_next_audit_due')
-              ->fields(['bundle' => $entity_type,
+              ->fields([
+                'bundle' => $entity_type,
                 'deleted' => 0,
                 'entity_id' => $nid,
                 'revision_id' => $vid,
                 'langcode' => $langcode,
                 'delta' => 0,
-                'field_next_audit_due_value' => $today])
+                'field_next_audit_due_value' => $today,
+              ])
               ->execute();
           }
         }

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -90,6 +90,7 @@ class MigrationProcessors {
         "SELECT vid FROM {node_field_data} WHERE nid = :nid", [':nid' => $row->nid]
       )->fetchField();
 
+      // Update the current revision if necessary.
       if ($vid != $d8_vid) {
         $vid = $this->updateCurrentRevision($row->nid, $vid, $d8_vid);
       }


### PR DESCRIPTION
Code to rectify four problems with the migration of revisions:

1. There were some revisions missing in D8. For example look at the revisions on node 12470 in your local db, revision 67236 will be missing.

2. When looking at the revisions tab for a node (use 12470 as an example again) none of the revisions show as published.

3. The current revision for a node is often incorrect after migration (node 12470 has revision 70645 set as current, it should be 70653)

4. During migration, the audit processing adds another revision - it is a better idea to amend the existing revision.
