### PR TITLE
D8 nid 486

### DIFF
--- a/migrate_nidirect_node/migrate_nidirect_node_application/config/install/migrate_plus.migration.node_application.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_application/config/install/migrate_plus.migration.node_application.yml
@@ -83,20 +83,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
   field_subtheme:
     -
       plugin: sub_process

--- a/migrate_nidirect_node/migrate_nidirect_node_article/config/install/migrate_plus.migration.node_article.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_article/config/install/migrate_plus.migration.node_article.yml
@@ -64,20 +64,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
   field_subtheme:
     -
       plugin: sub_process

--- a/migrate_nidirect_node/migrate_nidirect_node_contact/config/install/migrate_plus.migration.node_contact.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_contact/config/install/migrate_plus.migration.node_contact.yml
@@ -76,20 +76,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
 destination:
   plugin: 'entity:node'
   default_bundle: contact

--- a/migrate_nidirect_node/migrate_nidirect_node_health_condition/config/install/migrate_plus.migration.node_health_condition.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_health_condition/config/install/migrate_plus.migration.node_health_condition.yml
@@ -108,20 +108,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
   field_teaser: field_teaser
   field_top_level_theme:
     -

--- a/migrate_nidirect_node/migrate_nidirect_node_landing_page/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_landing_page/config/install/migrate_plus.migration.node_landing_page.yml
@@ -71,20 +71,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
   field_teaser: field_teaser
   field_top_level_theme:
     -

--- a/migrate_nidirect_node/migrate_nidirect_node_publication/config/install/migrate_plus.migration.node_embargoed_publication.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_publication/config/install/migrate_plus.migration.node_embargoed_publication.yml
@@ -87,20 +87,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
   field_top_level_theme:
     -
       plugin: sub_process

--- a/migrate_nidirect_node/migrate_nidirect_node_publication/config/install/migrate_plus.migration.node_publication.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node_publication/config/install/migrate_plus.migration.node_publication.yml
@@ -76,20 +76,7 @@ process:
       plugin: get
       source: field_summary
     -
-      plugin: media_wysiwyg_filter
-  field_summary/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: field_summary/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: strip_html_filter
   field_subtheme:
     -
       plugin: sub_process

--- a/migrate_nidirect_node/src/Plugin/migrate/process/StripHTMLFilter.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/process/StripHTMLFilter.php
@@ -22,13 +22,13 @@ class StripHTMLFilter extends ProcessPluginBase {
     // Reason for writing this filter was that a formatted text field in
     // Drupal 7 (the 'summary' field) was being converted to a plain
     // text field in Drupal 8.
-
-    // Replace any html entities with their text representation (including quotes).
+    // Firstly, replace any html entities with their text
+    // representation (including quotes).
     $value['value'] = html_entity_decode($value['value'], ENT_QUOTES);
 
     // Remove any HTML tags.
     $value['value'] = strip_tags($value['value']);
-    
+
     return $value;
   }
 

--- a/migrate_nidirect_node/src/Plugin/migrate/process/StripHTMLFilter.php
+++ b/migrate_nidirect_node/src/Plugin/migrate/process/StripHTMLFilter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\migrate_nidirect_node\Plugin\migrate\process;
+
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+
+/**
+ * Provides a 'StripHTMLFilter' migrate process plugin.
+ *
+ * @MigrateProcessPlugin(
+ *  id = "strip_html_filter"
+ * )
+ */
+class StripHTMLFilter extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    // Reason for writing this filter was that a formatted text field in
+    // Drupal 7 (the 'summary' field) was being converted to a plain
+    // text field in Drupal 8.
+
+    // Replace any html entities with their text representation (including quotes).
+    $value['value'] = html_entity_decode($value['value'], ENT_QUOTES);
+
+    // Remove any HTML tags.
+    $value['value'] = strip_tags($value['value']);
+    
+    return $value;
+  }
+
+}


### PR DESCRIPTION
Change migrations to account for the fact that the summary field is now plain text in D8. Introduced a new process filter strip_html_filter to remove html entities and tags from the (formatted long text) field as it comes in from D7.

Linked to https://github.com/dof-dss/nidirect-drupal/pull/275