### PR TITLE
D8 nid 790

### DIFF
--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -145,8 +145,28 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
         ->condition('content_entity_id', $nid)
         ->condition('content_entity_revision_id', $vid)
         ->execute();
-    }
+    } else {
+      // See if the moderation state on D7 was 'needs review'.
+      $moderation_status = $this->dbConnMigrate->query("
+      select state from {workbench_moderation_node_history} 
+      where hid = (select max(hid) from {workbench_moderation_node_history} where nid = :nid)
+        ", [':nid' => $nid])->fetchField();
+      if ($moderation_status == 'needs_review') {
+        // This node was in 'needs review' status on D7 so we need to make sure
+        // that it also looks like that on D8.
+        $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
+          ->fields(['moderation_state' => 'needs_review'])
+          ->condition('content_entity_id', $nid)
+          ->condition('content_entity_revision_id', $vid)
+          ->execute();
 
+        $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
+          ->fields(['moderation_state' => 'needs_review'])
+          ->condition('content_entity_id', $nid)
+          ->condition('content_entity_revision_id', $vid)
+          ->execute();
+      }
+    }
   }
 
   /**

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -132,18 +132,21 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
       ->condition('nid', $nid)
       ->execute();
 
-    // Make sure that we have a 'published' revision.
-    $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
-      ->fields(['moderation_state' => 'published'])
-      ->condition('content_entity_id', $nid)
-      ->condition('content_entity_revision_id', $vid)
-      ->execute();
+    if ($status == 1) {
+      // Make sure that we have a 'published' revision.
+      $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
+        ->fields(['moderation_state' => 'published'])
+        ->condition('content_entity_id', $nid)
+        ->condition('content_entity_revision_id', $vid)
+        ->execute();
 
-    $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
-      ->fields(['moderation_state' => 'published'])
-      ->condition('content_entity_id', $nid)
-      ->condition('content_entity_revision_id', $vid)
-      ->execute();
+      $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
+        ->fields(['moderation_state' => 'published'])
+        ->condition('content_entity_id', $nid)
+        ->condition('content_entity_revision_id', $vid)
+        ->execute();
+    }
+
   }
 
   /**

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostPublishStatusCommand.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\migrate_nidirect_utils\Command;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandler;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\ContainerAwareCommand;
@@ -145,7 +143,8 @@ class NidirectMigratePostPublishStatusCommand extends ContainerAwareCommand {
         ->condition('content_entity_id', $nid)
         ->condition('content_entity_revision_id', $vid)
         ->execute();
-    } else {
+    }
+    else {
       // See if the moderation state on D7 was 'needs review'.
       $moderation_status = $this->dbConnMigrate->query("
       select state from {workbench_moderation_node_history} 

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -130,15 +130,16 @@ class MigrationProcessors {
           ->condition('content_entity_id', $row->nid)
           ->condition('content_entity_revision_id', $vid)
           ->execute();
-      } else {
+      }
+      else {
         // See if the moderation state on D7 was 'needs review'.
         $moderation_status = $this->dbConnMigrate->query("
         select state from {workbench_moderation_node_history} 
         where hid = (select max(hid) from {workbench_moderation_node_history} where nid = :nid)
           ", [':nid' => $row->nid])->fetchField();
         if ($moderation_status == 'needs_review') {
-          // This node was in 'needs review' status on D7 so we need to make sure
-          // that it also looks like that on D8.
+          // This node was in 'needs review' status on D7 so we need to make
+          // sure that it also looks like that on D8.
           $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
             ->fields(['moderation_state' => 'needs_review'])
             ->condition('content_entity_id', $row->nid)

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -130,6 +130,27 @@ class MigrationProcessors {
           ->condition('content_entity_id', $row->nid)
           ->condition('content_entity_revision_id', $vid)
           ->execute();
+      } else {
+        // See if the moderation state on D7 was 'needs review'.
+        $moderation_status = $this->dbConnMigrate->query("
+        select state from {workbench_moderation_node_history} 
+        where hid = (select max(hid) from {workbench_moderation_node_history} where nid = :nid)
+          ", [':nid' => $row->nid])->fetchField();
+        if ($moderation_status == 'needs_review') {
+          // This node was in 'needs review' status on D7 so we need to make sure
+          // that it also looks like that on D8.
+          $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
+            ->fields(['moderation_state' => 'needs_review'])
+            ->condition('content_entity_id', $row->nid)
+            ->condition('content_entity_revision_id', $vid)
+            ->execute();
+
+          $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
+            ->fields(['moderation_state' => 'needs_review'])
+            ->condition('content_entity_id', $row->nid)
+            ->condition('content_entity_revision_id', $vid)
+            ->execute();
+        }
       }
 
     }

--- a/migrate_nidirect_utils/src/MigrationProcessors.php
+++ b/migrate_nidirect_utils/src/MigrationProcessors.php
@@ -117,18 +117,21 @@ class MigrationProcessors {
         ->condition('nid', $row->nid)
         ->execute();
 
-      // Make sure that we have a 'published' revision.
-      $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
-        ->fields(['moderation_state' => 'published'])
-        ->condition('content_entity_id', $row->nid)
-        ->condition('content_entity_revision_id', $vid)
-        ->execute();
+      if ($row->status == 1) {
+        // Make sure that we have a 'published' revision.
+        $query = $this->dbConnDrupal8->update('content_moderation_state_field_data')
+          ->fields(['moderation_state' => 'published'])
+          ->condition('content_entity_id', $row->nid)
+          ->condition('content_entity_revision_id', $vid)
+          ->execute();
 
-      $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
-        ->fields(['moderation_state' => 'published'])
-        ->condition('content_entity_id', $row->nid)
-        ->condition('content_entity_revision_id', $vid)
-        ->execute();
+        $query = $this->dbConnDrupal8->update('content_moderation_state_field_revision')
+          ->fields(['moderation_state' => 'published'])
+          ->condition('content_entity_id', $row->nid)
+          ->condition('content_entity_revision_id', $vid)
+          ->execute();
+      }
+
     }
 
     return 'Updated revisions for ' . count($migrate_nid_status) . ' nodes.';


### PR DESCRIPTION
Code improvements to handle migration of nodes from D7 that have a moderation state of 'needs review' - this state is now correctly preserved in D8 after migration.