### PR TITLE
D8NID-814 Skip over nidirect_gp alias handling because they aren't nodes in D8

### DIFF
--- a/migrate_nidirect_link/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/migrate_nidirect_link/src/EventSubscriber/PostMigrationSubscriber.php
@@ -73,6 +73,11 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
         $d7_path = $d7_alias->source;
         $d7_alias = $d7_alias->alias;
 
+        // Skip nidirect_gp node aliases; they aren't needed and can clash with new nodes in D8.
+        if (preg_match('|^services/gp-practices|', $d7_alias)) {
+          continue;
+        }
+
         // On D8, aliases and paths are prefixed with '/'.
         $d8_alias = '/' . $d7_alias;
         $d8_path = '/' . $d7_path;


### PR DESCRIPTION
GPs are supporting content represented as custom entities in D8. If we import their D7 node aliases, they associate with new nodes in D8 such as featured content lists causing much confusion :)