### PR TITLE
D8NID-850 Add drupal console command to clear existing feature/fcl nodes

### DIFF
--- a/migrate_nidirect_utils/console.services.yml
+++ b/migrate_nidirect_utils/console.services.yml
@@ -51,3 +51,8 @@ services:
     arguments: []
     tags:
       - { name: drupal.command }
+  migrate_nidirect_utils.nidirect_migrate_post_feature_nodes:
+    class: Drupal\migrate_nidirect_utils\Command\NidirectMigratePostFeatureNodesCommand
+    arguments: [ ]
+    tags:
+      - { name: drupal.command }

--- a/migrate_nidirect_utils/console.services.yml
+++ b/migrate_nidirect_utils/console.services.yml
@@ -46,3 +46,8 @@ services:
     arguments: []
     tags:
       - { name: drupal.command }
+  migrate_nidirect_utils.nidirect_migrate_pre_feature_nodes:
+    class: Drupal\migrate_nidirect_utils\Command\NidirectMigratePreFeatureNodesCommand
+    arguments: []
+    tags:
+      - { name: drupal.command }

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
@@ -53,7 +53,7 @@ class NidirectMigratePostFeatureNodesCommand extends ContainerAwareCommand {
     $this->featureContent[] = [
       'title' => 'Wear a face covering to help reduce spread of COVID-19',
       'teaser' => 'Wear a face covering to help reduce spread of COVID-19 - they are now mandatory in certain indoor settings',
-      'uri' => 'internal:/node/7680',
+      'uri' => 'internal:/node/13662',
       'media_id' => 8939,
     ];
     $this->featureContent[] = [

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
@@ -27,6 +27,9 @@ class NidirectMigratePostFeatureNodesCommand extends ContainerAwareCommand {
       ->setDescription("Post migration: Recreates feature + featured_content_list nodes after migration.");
   }
 
+  /**
+   * {@inheritdoc}
+   */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $this->task_create_feature_nodes();
     $this->task_create_feature_content_list_nodes();

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\migrate_nidirect_utils\Command;
+
+use Drupal\Console\Core\Command\ContainerAwareCommand;
+// @codingStandardsIgnoreStart
+use Drupal\Console\Annotations\DrupalCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+// @codingStandardsIgnoreEnd
+/**
+ * Recreates known feature and featured_content_list nodes after migration.
+ *
+ * @DrupalCommand (
+ *     extension="migrate_nidirect_utils",
+ *     extensionType="module"
+ * )
+ */
+class NidirectMigratePostFeatureNodesCommand extends ContainerAwareCommand {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this->setName('nidirect:migrate:post:feature_nodes')
+      ->setDescription("Post migration: Recreates feature + featured_content_list nodes after migration.");
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->task_create_feature_nodes();
+    $this->task_create_feature_content_list_nodes();
+
+    $this->getIo()->info('DONE!');
+  }
+
+  /**
+   * Re-create feature nodes from defined content.
+   */
+  // phpcs:disable
+  protected function task_create_feature_nodes() {
+  // phpcs:enable
+
+  }
+
+  /**
+   * Re-create featured content list nodes from defined content.
+   */
+  // phpcs:disable
+  protected function task_create_feature_content_list_nodes() {
+    // phpcs:enable
+
+  }
+
+}

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePostFeatureNodesCommand.php
@@ -20,6 +20,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class NidirectMigratePostFeatureNodesCommand extends ContainerAwareCommand {
 
+  /**
+   * A collection of featured content data.
+   * @var array
+   */
   protected $featureContent = [];
 
   /**
@@ -107,7 +111,7 @@ class NidirectMigratePostFeatureNodesCommand extends ContainerAwareCommand {
       'features' => [
         ['target_id' => $this->getFeatureByTitle('Wear a face covering to help reduce spread of COVID-19')],
         ['target_id' => $this->getFeatureByTitle('Universal Credit')],
-        ['target_id' => $this->getFeatureByTitle( 'Coronavirus (COVID-19)')],
+        ['target_id' => $this->getFeatureByTitle('Coronavirus (COVID-19)')],
       ],
       'tag' => 1338,
     ];
@@ -133,7 +137,7 @@ class NidirectMigratePostFeatureNodesCommand extends ContainerAwareCommand {
    * Fetches the node id of a feature node from a given title.
    *
    * @param string $title
-   *   Feature node title
+   *   Feature node title.
    * @return int
    *   The node id.
    */

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePreFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePreFeatureNodesCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\migrate_nidirect_utils\Command;
+
+use Drupal\Console\Core\Command\ContainerAwareCommand;
+// @codingStandardsIgnoreStart
+use Drupal\Console\Annotations\DrupalCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+// @codingStandardsIgnoreEnd
+/**
+ * Processes the database prior to migration.
+ *
+ * @DrupalCommand (
+ *     extension="migrate_nidirect_utils",
+ *     extensionType="module"
+ * )
+ */
+class NidirectMigratePreFeatureNodesCommand extends ContainerAwareCommand {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this->setName('nidirect:migrate:pre:feature_nodes')
+      ->setDescription("Pre migration setup: removes feature and FCL nodes");
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->getIo()->info('Removing existing feature and featured_content_list nodes before migration.');
+    $this->task_remove_feature_fcl_nodes();
+    $this->getIo()->info('DONE!');
+  }
+
+  /**
+   * Purge the D8 site of all feature and featured content list nodes.
+   */
+  // phpcs:disable
+  protected function task_remove_feature_fcl_nodes() {
+  // phpcs:enable
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+    foreach (['featured_content_list', 'feature'] as $type) {
+      $entities = $storage->loadByProperties(['type' => $type]);
+      $storage->delete($entities);
+    }
+  }
+
+}

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePreFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePreFeatureNodesCommand.php
@@ -27,6 +27,9 @@ class NidirectMigratePreFeatureNodesCommand extends ContainerAwareCommand {
       ->setDescription("Pre migration setup: removes feature and FCL nodes");
   }
 
+  /**
+   * {@inheritdoc}
+   */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $this->getIo()->info('Removing existing feature and featured_content_list nodes before migration.');
     $this->task_remove_feature_fcl_nodes();

--- a/migrate_nidirect_utils/src/Command/NidirectMigratePreFeatureNodesCommand.php
+++ b/migrate_nidirect_utils/src/Command/NidirectMigratePreFeatureNodesCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 // @codingStandardsIgnoreEnd
 /**
- * Processes the database prior to migration.
+ * Removes existing feature + featured_content_list nodes ahead of content import.
  *
  * @DrupalCommand (
  *     extension="migrate_nidirect_utils",


### PR DESCRIPTION
Two drupal console commands to make it easier to manage content id 'drift' when importing legacy content. Run the pre command to clear out existing feature/FCL content... then post command to recreate things.