### PR TITLE
D8NID-919

### DIFF
--- a/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_document.yml
+++ b/migrate_nidirect_file/config/install/migrate_plus.migration.upgrade_d7_file_document.yml
@@ -34,7 +34,7 @@ process:
   status: status
   created: timestamp
   changed: timestamp
-  field_media_file_1/target_id: fid
+  field_media_file/target_id: fid
   field_media_doc_file_language: field_file_language
   field_media_doc_file_title: field_file_title
 destination:


### PR DESCRIPTION
Migration bug fix first discovered on Unity.
Ensure that media documents are correctly linked to files (currently none of the media documents contain valid links to files)