### PR TITLE
Add redirect callback and services

### DIFF
--- a/migrate_nidirect_node/migrate_nidirect_node.info.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - drupal:migrate_tools
   - migrate_nidirect_user
   - migrate_nidirect_taxo
+  - redirect

--- a/migrate_nidirect_node/migrate_nidirect_node.services.yml
+++ b/migrate_nidirect_node/migrate_nidirect_node.services.yml
@@ -7,6 +7,6 @@ services:
 
   migrate_nidirect_node.eventsubscriber.post:
     class: 'Drupal\migrate_nidirect_node\EventSubscriber\PostMigrationSubscriber'
-    arguments: ['@entity_type.manager', '@logger.factory', '@migrate_nidirect_utils.migrationprocessors']
+    arguments: ['@entity_type.manager', '@logger.factory', '@migrate_nidirect_utils.migrationprocessors', '@redirect.repository']
     tags:
         - { name: 'event_subscriber' }


### PR DESCRIPTION
Allows us to tie up some loose ends from the D7 migration using the built in redirect module, rather than bundle them into something cruder like nginx config or .htaccess