### PR TITLE
If absolute link for nidirect is detected, pare it back to just the path

### DIFF
--- a/migrate_nidirect_utils/src/ContentProcessors.php
+++ b/migrate_nidirect_utils/src/ContentProcessors.php
@@ -19,16 +19,16 @@ class ContentProcessors {
    *   Array of Drupal Link field values..
    */
   public static function relatedLinks(array $content) {
-
     // Find the character index of the Useful links heading.
-    $links_header_position = strpos($content[0][0]['value'], 'More useful links');
+    $value = $content[0][0]['value'];
+    $links_header_position = strpos($value, 'More useful links');
 
     if ($links_header_position === FALSE) {
       return [];
     }
 
     // Extract everything after the 'More useful links'.
-    $links_markup = substr($content[0][0]['value'], $links_header_position);
+    $links_markup = substr($value, $links_header_position);
     // Extract uri and text.
     $link_regex = '/<a href="(\S+?)".*?>\s*([^<]*)<\//m';
     preg_match_all($link_regex, $links_markup, $matches, PREG_SET_ORDER, 0);
@@ -37,6 +37,11 @@ class ContentProcessors {
 
     // Create a Drupal link field entry for each extracted HTML link element.
     foreach ($matches as $link) {
+      // Prune away any absolute paths for NIDirect.
+      if (preg_match('/^http(.+)nidirect.gov.uk/', $link[1])) {
+        $link[1] = parse_url($link[1], PHP_URL_PATH);
+      }
+
       $links[] = [
         'uri' => (strpos($link[1], '/') === 0 ? 'internal:' . $link[1] : $link[1]),
         'title' => strip_tags(html_entity_decode($link[2])),


### PR DESCRIPTION
Passing `internal:/some-path` into the process plugin stores it as that value but when rendering the widget on the node edit form it converts the value to the canonical internal path. Either way, the link works and isn't absolute.